### PR TITLE
fix: allow unset database_arn for serverless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   terraform:
     docker:
-      - image: cimg/deploy:2023.05
+      - image: cimg/deploy:2024.03.1
   node:
     docker:
       - image: cimg/node:current

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
           command: |
             terraform init -backend=false
             terraform validate
+      - run:
+          step_name: Run Terraform Test
+          command: terraform test
+
   
   terraform_docs:
     executor: tf_docs

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.tfstate
 *.tfstate.*
 
+# local lock file
+*.terraform.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 *.tfstate
 *.tfstate.*
 
-# local lock file
-*.terraform.lock.hcl
-
 # Crash log files
 crash.log
 

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.55.0"
+  constraints = ">= 4.66.0"
+  hashes = [
+    "h1:vChl08zNYLVzuSzfxz3wp3wNSx+vjwl/jPuyPbg59Ks=",
+    "zh:06fbb1cc4b61b9d6370d391bf7538aa6ef8b60b91c67d125a6be60a70b1d49f0",
+    "zh:1d52acd2184f379433a0fce2c29d5ed8fc7958d6a9d1b403310dcc36b2a3f626",
+    "zh:290bbce092f8836a1db530ac86d933cfea27d52b827639974a81bc48dfba8c34",
+    "zh:3531f2822c2de3ba837381c4ee4816c5b437fd204c07d659526a04d9154a65e8",
+    "zh:56d70db4c8c6c0ec1b665380b87726275f4ab3665b4b78ac86dc90e1010c0fe3",
+    "zh:8251d713c0b2c8c51b6858e51c70d083b484342ff9782a88c39e7eaa966c3da2",
+    "zh:9a7d1f7207e51382a7dd139dfd5786e7e905edf9bf89bbee4b59ad41365e87be",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a529c78dfc60063289524690af78794e99a768835b88e27cdfec15bc85439f7c",
+    "zh:b6da1843355db05c5d412126406fd97db2a6ff9edc166b81c1cea2994535b4eb",
+    "zh:bfc08cd23b1556b3287d1b28ac7f12c7d459471d97a0592bf2579ea68d11bae7",
+    "zh:c382088faf05894191636b57861069a21de10a5ff4eb8f7cc122e764ccf7a4a8",
+    "zh:e27f99f389921314ee428b24990d3a829057ce532b2beb33c69387458722edd9",
+    "zh:ef11285eedb45ffc3fb2ecdfefa206e64eb2760a87fff15c44dee42de9703436",
+    "zh:fedc4ebee0d6fe196691127004db5d1ff8bd22e3b667a74026bb92c607589b6c",
+  ]
+}

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,20 @@
+mock_provider "aws" {}
+
+run "valid_serverless_minimal_details" {
+  command = plan
+
+  variables {
+    vpc_id = "my-vpc"
+    workgroup_arn = "workgroup_arn"
+    s3_bucket_name = "my-bucket"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.allow_fullstory_ips_0.cidr_ipv4 == "8.35.195.0/29"
+    error_message = "default cidr block is wrong"
+  }
+  assert {
+    condition = jsondecode(aws_iam_role.main.assume_role_policy).Statement[0].Condition.StringEquals["accounts.google.com:aud"] == "116984388253902328461"
+    error_message = "default oauth id is wrong"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "database_arn" {
   description = "The ARN of the database within Redshift cluster. Required if you are using Redshift provisioned. This is not the cluster ARN, see https://docs.aws.amazon.com/redshift/latest/mgmt/generating-iam-credentials-role-permissions.html for more information."
   default     = ""
   validation {
-    condition     = can(regex("arn:aws:redshift:[a-z0-9-]+:.*:dbname:[a-z0-9-]+/.+", var.database_arn))
+    condition     = var.database_arn == "" || can(regex("arn:aws:redshift:[a-z0-9-]+:.*:dbname:[a-z0-9-]+/.+", var.database_arn))
     error_message = "The cluster ARN must include 'dbname' name. Ex. arn:aws:redshift:us-west-2:123456789012:dbname:my-cluster/my-database"
   }
 }


### PR DESCRIPTION
## Description

The existing validation on `database_arn` does not allow unset when using serverless. 

This updates the validation to include a null check.

I also updated the circle job to add `terraform test` since this wasn't caught by `terraform validate`. 

## Checklist before submitting PR for review

- [ ] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
