### PR TITLE
fix: use is_serverless so that output is deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This module creates all the proper policies, roles and S3 buckets so that Fullst
 | <a name="input_fullstory_cidr_ipv4s"></a> [fullstory\_cidr\_ipv4s](#input\_fullstory\_cidr\_ipv4s) | The CIDR block that Fullstory will use to connect to the Redshift cluster. | `list(string)` | `[]` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_google_audience"></a> [fullstory\_google\_audience](#input\_fullstory\_google\_audience) | The Google audience identifier that Fullstory will use to assume the role in order to call AWS APIs | `string` | `""` | no |
-| <a name="input_is_serverless"></a> [is\_serverless](#input\_is\_serverless) | Whether the Redshift cluster is serverless or not. | `bool` | n/a | yes |
+| <a name="input_is_serverless"></a> [is\_serverless](#input\_is\_serverless) | Whether the Redshift cluster is serverless or not. If true, workgroup\_arn is required. If false, database\_arn is required. | `bool` | n/a | yes |
 | <a name="input_port"></a> [port](#input\_port) | The port number where the Redshift cluster is listening. | `number` | `5439` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket where the Fullstory bundles are stored. | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where the Redshift cluster or Redshift Serverless workgroup is deployed. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This module creates all the proper policies, roles and S3 buckets so that Fullst
 | <a name="input_fullstory_cidr_ipv4s"></a> [fullstory\_cidr\_ipv4s](#input\_fullstory\_cidr\_ipv4s) | The CIDR block that Fullstory will use to connect to the Redshift cluster. | `list(string)` | `[]` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_google_audience"></a> [fullstory\_google\_audience](#input\_fullstory\_google\_audience) | The Google audience identifier that Fullstory will use to assume the role in order to call AWS APIs | `string` | `""` | no |
+| <a name="input_is_serverless"></a> [is\_serverless](#input\_is\_serverless) | Whether the Redshift cluster is serverless or not. | `bool` | n/a | yes |
 | <a name="input_port"></a> [port](#input\_port) | The port number where the Redshift cluster is listening. | `number` | `5439` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket where the Fullstory bundles are stored. | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where the Redshift cluster or Redshift Serverless workgroup is deployed. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,16 @@ locals {
   fullstory_google_audience = var.fullstory_google_audience != "" ? var.fullstory_google_audience : (var.fullstory_data_center == "EU1" ? "107589159240321051166" : "116984388253902328461")
 }
 
+resource "validation_error" "is_serverless_workgroup_arn" {
+  condition = var.is_serverless && var.workgroup_arn == ""
+  summary   = "workgroup_arn is required when is_serverless=true"
+}
+
+resource "validation_error" "is_serverless_database_arn" {
+  condition = !var.is_serverless && var.database_arn == ""
+  summary   = "database_arn is required when is_serverless=true"
+}
+
 data "aws_vpc" "main" {
   id = var.vpc_id
 }

--- a/main.tf
+++ b/main.tf
@@ -3,16 +3,6 @@ locals {
   fullstory_google_audience = var.fullstory_google_audience != "" ? var.fullstory_google_audience : (var.fullstory_data_center == "EU1" ? "107589159240321051166" : "116984388253902328461")
 }
 
-resource "validation_error" "is_serverless_workgroup_arn" {
-  condition = var.is_serverless && var.workgroup_arn == ""
-  summary   = "workgroup_arn is required when is_serverless=true"
-}
-
-resource "validation_error" "is_serverless_database_arn" {
-  condition = !var.is_serverless && var.database_arn == ""
-  summary   = "database_arn is required when is_serverless=true"
-}
-
 data "aws_vpc" "main" {
   id = var.vpc_id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
   fullstory_cidr_ipv4s      = length(var.fullstory_cidr_ipv4s) > 0 ? var.fullstory_cidr_ipv4s : (var.fullstory_data_center == "EU1" ? ["34.89.210.80/29"] : ["8.35.195.0/29"])
   fullstory_google_audience = var.fullstory_google_audience != "" ? var.fullstory_google_audience : (var.fullstory_data_center == "EU1" ? "107589159240321051166" : "116984388253902328461")
-  is_serverless             = var.workgroup_arn != ""
 }
 
 data "aws_vpc" "main" {
@@ -80,14 +79,14 @@ resource "aws_s3_bucket_policy" "main" {
 }
 
 module "redshift_serverless" {
-  count         = local.is_serverless ? 1 : 0
+  count         = var.is_serverless ? 1 : 0
   source        = "./modules/serverless"
   workgroup_arn = var.workgroup_arn
   role_name     = aws_iam_role.main.name
 }
 
 module "redshift_provisioned" {
-  count              = local.is_serverless ? 0 : 1
+  count              = var.is_serverless ? 0 : 1
   source             = "./modules/provisioned"
   cluster_identifier = var.cluster_identifier
   database_arn       = var.database_arn

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -19,3 +19,18 @@ run "valid_serverless_minimal_details" {
     error_message = "default oauth id is wrong"
   }
 }
+
+run "serverless_no_workgroup_arn" {
+  command = plan
+
+  variables {
+    vpc_id         = "my-vpc"
+    s3_bucket_name = "my-bucket"
+    is_serverless  = true
+  }
+
+  assert {
+    condition     = validation_error.is_serverless_workgroup_arn
+    error_message = "workgroup_arn is required when is_serverless=true"
+  }
+}

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -7,6 +7,7 @@ run "valid_serverless_minimal_details" {
     vpc_id         = "my-vpc"
     workgroup_arn  = "workgroup_arn"
     s3_bucket_name = "my-bucket"
+    is_serverless  = true
   }
 
   assert {

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -19,18 +19,3 @@ run "valid_serverless_minimal_details" {
     error_message = "default oauth id is wrong"
   }
 }
-
-run "serverless_no_workgroup_arn" {
-  command = plan
-
-  variables {
-    vpc_id         = "my-vpc"
-    s3_bucket_name = "my-bucket"
-    is_serverless  = true
-  }
-
-  assert {
-    condition     = validation_error.is_serverless_workgroup_arn
-    error_message = "workgroup_arn is required when is_serverless=true"
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -61,10 +61,5 @@ variable "workgroup_arn" {
   type        = string
   description = "The ARN of the Redshift Serverless workgroup. Required if you are using Redshift Serverless."
   default     = ""
-
-  validation {
-    condition     = var.is_serverless && var.workgroup_arn == ""
-    error_message = "workgroup_arn is required when is_serverless=true"
-  }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,11 @@ variable "fullstory_data_center" {
   }
 }
 
+variable "is_serverless" {
+  type        = bool
+  description = "Whether the Redshift cluster is serverless or not."
+}
+
 variable "port" {
   type        = number
   description = "The port number where the Redshift cluster is listening."

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "fullstory_data_center" {
 
 variable "is_serverless" {
   type        = bool
-  description = "Whether the Redshift cluster is serverless or not."
+  description = "Whether the Redshift cluster is serverless or not. If true, workgroup_arn is required. If false, database_arn is required."
 }
 
 variable "port" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,5 +61,10 @@ variable "workgroup_arn" {
   type        = string
   description = "The ARN of the Redshift Serverless workgroup. Required if you are using Redshift Serverless."
   default     = ""
+
+  validation {
+    condition     = var.is_serverless && var.workgroup_arn == ""
+    error_message = "workgroup_arn is required when is_serverless=true"
+  }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description

This uses a new variable `is_serverless` so that the resources created by the module are deterministic.

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
