### PR TITLE
fix: add prefix to differentiate other instantiations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This module creates all the proper policies, roles and S3 buckets so that Fullst
 | <a name="input_fullstory_google_audience"></a> [fullstory\_google\_audience](#input\_fullstory\_google\_audience) | The Google audience identifier that Fullstory will use to assume the role in order to call AWS APIs | `string` | `""` | no |
 | <a name="input_is_serverless"></a> [is\_serverless](#input\_is\_serverless) | Whether the Redshift cluster is serverless or not. If true, workgroup\_arn is required. If false, database\_arn is required. | `bool` | n/a | yes |
 | <a name="input_port"></a> [port](#input\_port) | The port number where the Redshift cluster is listening. | `number` | `5439` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to use for the resources created by this module. | `string` | `"fullstory"` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket where the Fullstory bundles are stored. | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where the Redshift cluster or Redshift Serverless workgroup is deployed. | `string` | n/a | yes |
 | <a name="input_workgroup_arn"></a> [workgroup\_arn](#input\_workgroup\_arn) | The ARN of the Redshift Serverless workgroup. Required if you are using Redshift Serverless. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_vpc" "main" {
 }
 
 resource "aws_security_group" "allow_fullstory_ips" {
-  name        = "fullstory-allow-fullstory-ips"
+  name        = "${var.prefix}-allow-fullstory-ips"
   description = "Allow Redshift traffic from Fullstory IPs"
   vpc_id      = var.vpc_id
 }
@@ -23,7 +23,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_fullstory_ips" {
 }
 
 resource "aws_iam_role" "main" {
-  name = "fullstory_redshift_setup"
+  name = "${var.prefix}_redshift_setup"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -79,8 +79,10 @@ resource "aws_s3_bucket_policy" "main" {
 }
 
 module "redshift_serverless" {
-  count         = var.is_serverless ? 1 : 0
-  source        = "./modules/serverless"
+  count  = var.is_serverless ? 1 : 0
+  source = "./modules/serverless"
+
+  prefix        = var.prefix
   workgroup_arn = var.workgroup_arn
   role_name     = aws_iam_role.main.name
 }
@@ -90,5 +92,6 @@ module "redshift_provisioned" {
   source             = "./modules/provisioned"
   cluster_identifier = var.cluster_identifier
   database_arn       = var.database_arn
+  prefix             = var.prefix
   role_name          = aws_iam_role.main.name
 }

--- a/modules/provisioned/main.tf
+++ b/modules/provisioned/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "main" {
-  name        = "fullstory_get_credentials"
+  name        = "${var.prefix}_get_credentials"
   path        = "/"
   description = "Allows Fullstory to get credentials to the Redshift Serverless workgroup"
   policy = jsonencode({

--- a/modules/provisioned/variables.tf
+++ b/modules/provisioned/variables.tf
@@ -12,6 +12,12 @@ variable "database_arn" {
   }
 }
 
+variable "prefix" {
+  type        = string
+  description = "The prefix to use for the resources created by this module."
+  default     = "fullstory"
+}
+
 variable "role_name" {
   type        = string
   description = "The name of the role that Fullstory will assume to get credentials to the Redshift cluster."

--- a/modules/serverless/main.tf
+++ b/modules/serverless/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "main" {
-  name        = "fullstory_get_credentials"
+  name        = "${var.prefix}_get_credentials"
   path        = "/"
   description = "Allows Fullstory to get credentials to the Redshift Serverless workgroup"
   policy = jsonencode({

--- a/modules/serverless/variables.tf
+++ b/modules/serverless/variables.tf
@@ -1,3 +1,9 @@
+variable "prefix" {
+  type        = string
+  description = "The prefix to use for the resources created by this module."
+  default     = "fullstory"
+}
+
 variable "role_name" {
   type        = string
   description = "The name of the role that Fullstory will assume to get credentials to the Redshift Serverless workgroup."

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "port" {
   default     = 5439
 }
 
+variable "prefix" {
+  type        = string
+  description = "The prefix to use for the resources created by this module."
+  default     = "fullstory"
+}
+
 variable "s3_bucket_name" {
   type        = string
   description = "The name of the S3 bucket where the Fullstory bundles are stored."


### PR DESCRIPTION
## Description

This adds a prefix that you can use to delineate resources created by different instances of this module. It has a default value of `fullstory` so that it is backwards compatible.

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
