### PR TITLE
fix: remove ip address variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This module creates all the proper policies, roles and S3 buckets so that Fullstory can connect to the Redshift Cluster or Workgroup and load data. For more information checkout [this KB article](https://help.fullstory.com/hc/en-us/articles/18791516308887-Amazon-Redshift).
 
-**This module does not** create the permissions in your database that are required for Fullstory to create schemas. See [this guide](https://help.fullstory.com/hc/en-us/articles/18791516308887-Amazon-Redshift#h_01HNGMBXC344AM02MR35QFZJ2T) for instructions on how to grant your IAM role the correct permissions on your database objects.
+**This module does not** create the permissions in your database that are required for Fullstory to create schemas nor does it add security groups to your cluster or workgroup. See [this guide](https://help.fullstory.com/hc/en-us/articles/18791516308887-Amazon-Redshift#h_01HNGMBXC344AM02MR35QFZJ2T) for instructions on how to grant your IAM role the correct permissions on your database objects.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -22,7 +22,6 @@ This module creates all the proper policies, roles and S3 buckets so that Fullst
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | The identifier of the Redshift cluster. Required if you are using Redshift provisioned. | `string` | `""` | no |
 | <a name="input_database_arn"></a> [database\_arn](#input\_database\_arn) | The ARN of the database within Redshift cluster. Required if you are using Redshift provisioned. This is not the cluster ARN, see https://docs.aws.amazon.com/redshift/latest/mgmt/generating-iam-credentials-role-permissions.html for more information. | `string` | `""` | no |
-| <a name="input_fullstory_cidr_ipv4s"></a> [fullstory\_cidr\_ipv4s](#input\_fullstory\_cidr\_ipv4s) | The CIDR block that Fullstory will use to connect to the Redshift cluster. | `list(string)` | `[]` | no |
 | <a name="input_fullstory_data_center"></a> [fullstory\_data\_center](#input\_fullstory\_data\_center) | The data center where your Fullstory account is hosted. Either 'NA1' or 'EU1'. See https://help.fullstory.com/hc/en-us/articles/8901113940375-Fullstory-Data-Residency for more information. | `string` | `"NA1"` | no |
 | <a name="input_fullstory_google_audience"></a> [fullstory\_google\_audience](#input\_fullstory\_google\_audience) | The Google audience identifier that Fullstory will use to assume the role in order to call AWS APIs | `string` | `""` | no |
 | <a name="input_is_serverless"></a> [is\_serverless](#input\_is\_serverless) | Whether the Redshift cluster is serverless or not. If true, workgroup\_arn is required. If false, database\_arn is required. | `bool` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,9 @@
 locals {
-  fullstory_cidr_ipv4s      = length(var.fullstory_cidr_ipv4s) > 0 ? var.fullstory_cidr_ipv4s : (var.fullstory_data_center == "EU1" ? ["34.89.210.80/29"] : ["8.35.195.0/29"])
   fullstory_google_audience = var.fullstory_google_audience != "" ? var.fullstory_google_audience : (var.fullstory_data_center == "EU1" ? "107589159240321051166" : "116984388253902328461")
 }
 
 data "aws_vpc" "main" {
   id = var.vpc_id
-}
-
-resource "aws_security_group" "allow_fullstory_ips" {
-  name        = "${var.prefix}-allow-fullstory-ips"
-  description = "Allow Redshift traffic from Fullstory IPs"
-  vpc_id      = var.vpc_id
-}
-
-resource "aws_vpc_security_group_ingress_rule" "allow_fullstory_ips" {
-  count             = length(local.fullstory_cidr_ipv4s)
-  security_group_id = aws_security_group.allow_fullstory_ips.id
-  cidr_ipv4         = local.fullstory_cidr_ipv4s[count.index]
-  ip_protocol       = "tcp"
-  from_port         = var.port
-  to_port           = var.port
 }
 
 resource "aws_iam_role" "main" {

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -11,10 +11,6 @@ run "valid_serverless_minimal_details" {
   }
 
   assert {
-    condition     = aws_vpc_security_group_ingress_rule.allow_fullstory_ips[0].cidr_ipv4 == "8.35.195.0/29"
-    error_message = "default cidr block is wrong"
-  }
-  assert {
     condition     = jsondecode(aws_iam_role.main.assume_role_policy).Statement[0].Condition.StringEquals["accounts.google.com:aud"] == "116984388253902328461"
     error_message = "default oauth id is wrong"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "cluster_identifier" {
   default     = ""
 }
 
-variable "fullstory_cidr_ipv4s" {
-  type        = list(string)
-  description = "The CIDR block that Fullstory will use to connect to the Redshift cluster."
-  default     = []
-}
-
 variable "fullstory_google_audience" {
   type        = string
   description = "The Google audience identifier that Fullstory will use to assume the role in order to call AWS APIs"


### PR DESCRIPTION
## Description
We use to create security groups that would allow the Fullstory IPs to connect to Redshift ports. This is not a very nice contract because you need to know the security groups at the time you create your Redshift cluster or workgroup.

This removes the creation and transfers the power back to the caller of this module.

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
