### PR TITLE
fix: don't allow dashes in role name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ data "aws_vpc" "main" {
 }
 
 resource "aws_iam_role" "main" {
-  name = "${var.prefix}_redshift_setup"
+  name = "${replace(var.prefix, "-", "_")}_redshift_setup"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -4,10 +4,16 @@ run "valid_serverless_minimal_details" {
   command = plan
 
   variables {
+    prefix         = "my-prefix"
     vpc_id         = "my-vpc"
     workgroup_arn  = "workgroup_arn"
     s3_bucket_name = "my-bucket"
     is_serverless  = true
+  }
+
+  assert {
+    condition     = aws_iam_role.main.name == "my_prefix_redshift_setup"
+    error_message = "role name is wrong"
   }
 
   assert {


### PR DESCRIPTION
## Description

Because this role name can be used as a SQL username, we cannot allow dashes. We will replace all dashes with underscores.

## Checklist before submitting PR for review

- [x] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
